### PR TITLE
Adding an anti-bruteforce mechanism on the administration pages login.

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -77,7 +77,7 @@ if (NOS_ENTRY_POINT != 'admin') {
             ),
         ))->count();
 
-        if ($failures >= \Arr::get($wait_failures_config, 'attempts', 3)) {
+        if ($failures >= \Arr::get($wait_failures_config, 'attempts', 10)) {
             $error = __('You failed to login too many times. Please wait before trying again.');
             if (\Input::is_ajax()) {
                 $controller->sendResponse(array('error' => $error));

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -62,7 +62,7 @@ if (NOS_ENTRY_POINT != 'admin') {
     $wait_failures_enabled = \Arr::get($wait_failures_config, 'enabled', true);
     $callback_is_whitelisted = \Arr::get($wait_failures_config, 'is_whitelisted');
 
-    if ($wait_failures_enabled && is_callable($callback_is_whitelisted) && !$callback_is_whitelisted()) {
+    if ($wait_failures_enabled && (!is_callable($callback_is_whitelisted) || !$callback_is_whitelisted())) {
         $time_from = \Date::forge()
             ->modify('-'.\Arr::get($wait_failures_config, 'time_to_wait', 300).' seconds')
             ->format('mysql');

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -58,10 +58,11 @@ if (NOS_ENTRY_POINT != 'admin') {
 
 \Event::register_function('admin.beforeLogin', function ($params) {
     $controller = \Arr::get($params, 'controllerInstance');
-    $wait_failures_config = \Config::load('novius_loginhistory::wait_after_admin_login_failures', true);
+    $wait_failures_config = \Arr::get(\Config::load('novius_loginhistory::config', true), 'wait_after_admin_login_failures', []);
     $wait_failures_enabled = \Arr::get($wait_failures_config, 'enabled', true);
+    $callback_is_whitelisted = \Arr::get($wait_failures_config, 'is_whitelisted');
 
-    if ($wait_failures_enabled) {
+    if ($wait_failures_enabled && is_callable($callback_is_whitelisted) && !$callback_is_whitelisted()) {
         $time_from = \Date::forge()
             ->modify('-'.\Arr::get($wait_failures_config, 'time_to_wait', 300).' seconds')
             ->format('mysql');

--- a/config/config.php
+++ b/config/config.php
@@ -12,4 +12,15 @@ return array(
     'callback_ip'   => function() {
         return Input::ip();
     },
+
+    /**
+     * After login failures on the back-office, forces the user to wait X seconds before re-trying
+     */
+    'wait_after_admin_login_failures' => array(
+        'enabled' => true,
+        // Number of attemps before being blocked.
+        'attempts' => 10,
+        // Time to wait (seconds)
+        'time_to_wait' => 300,
+    ),
 );

--- a/config/config.php
+++ b/config/config.php
@@ -22,5 +22,9 @@ return array(
         'attempts' => 10,
         // Time to wait (seconds)
         'time_to_wait' => 300,
+        // In case you need to setup a mechanism to whitelist someone
+        'is_whitelisted' => function() {
+            return false;
+        }
     ),
 );


### PR DESCRIPTION
There doesn't seem to be a better way to return the page's content with the error without manually building a new Response object.