### PR TITLE
Fix log of email and user_id on login success

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -13,14 +13,14 @@ if (NOS_ENTRY_POINT != 'admin') {
 }
 
 // On login success
-\Event::register('admin.loginSuccess', function () {
-    $user = Session::user();
+\Event::register_function('admin.beforeLoginSuccess', function ($params) {
+    $user = \Arr::get((array) $params, 'user');
     \Novius\Loginhistory\Model_Login::add('login', array(
         'driver'    => 'nos',
         'method'    => 'form',
         'state'     => 'success',
-        'login'     => $user->user_email,
-        'user_id'   => $user->user_id,
+        'login'     => !empty($user) ? $user->user_email : null,
+        'user_id'   => !empty($user) ? $user->user_id : null,
     ));
 });
 
@@ -36,13 +36,13 @@ if (NOS_ENTRY_POINT != 'admin') {
 
 // On autologin success
 \Event::register('admin.loginSuccessWithCookie', function () {
-    $user = Session::user();
+    $user = \Arr::get((array) $params, 'user');
     \Novius\Loginhistory\Model_Login::add('login', array(
         'driver'    => 'nos',
         'method'    => 'cookie',
         'state'     => 'success',
-        'login'     => $user->user_email,
-        'user_id'   => $user->user_id,
+        'login'     => !empty($user) ? $user->user_email : null,
+        'user_id'   => !empty($user) ? $user->user_id : null,
     ));
 });
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -35,7 +35,7 @@ if (NOS_ENTRY_POINT != 'admin') {
 });
 
 // On autologin success
-\Event::register('admin.loginSuccessWithCookie', function () {
+\Event::register_function('admin.loginSuccessWithCookie', function ($params) {
     $user = \Arr::get((array) $params, 'user');
     \Novius\Loginhistory\Model_Login::add('login', array(
         'driver'    => 'nos',


### PR DESCRIPTION
When `admin.loginSuccess` is triggered the session doesn't exist, instead we can use `admin.beforeLoginSuccess` which has the user given as a parameter.

With `admin.loginSuccessWithCookie` the `Session::user();` will return the user but for consistency it's better to take the user given as a parameter.